### PR TITLE
[VAN-126384] packages renaming

### DIFF
--- a/sdk-blueprints/python/api/.openapi-generator-ignore
+++ b/sdk-blueprints/python/api/.openapi-generator-ignore
@@ -3,12 +3,8 @@ docs/
 .github/
 
 # Ignore core library .py files
-visier/sdk/api/*/*.py
-!visier/sdk/api/*/__init__.py
-
-# Resolving pytest import errors: init.py in /test/ causes conflicts
-# Removing init.py ensures pytest prioritizes installed packages, avoiding ambiguity.
-/test/__init__.py
+visier_api*/*.py
+!visier_api*/__init__.py
 
 # Ignore files in the root by default
 /*

--- a/sdk-blueprints/python/api/templates/api.mustache
+++ b/sdk-blueprints/python/api/templates/api.mustache
@@ -6,7 +6,7 @@ from pydantic import validate_call, Field, StrictFloat, StrictStr, StrictInt
 from typing import Any, Dict, List, Optional, Tuple, Union
 from typing_extensions import Annotated
 
-from {{corePackageName}} import ApiClient, ApiResponse, RequestSerialized, RESTResponseType
+from {{corePackageModule}} import ApiClient, ApiResponse, RequestSerialized, RESTResponseType
 
 {{#imports}}
 {{import}}

--- a/sdk-blueprints/python/api/templates/pyproject.mustache
+++ b/sdk-blueprints/python/api/templates/pyproject.mustache
@@ -12,7 +12,7 @@ include = ["{{packageName}}/py.typed"]
 [tool.poetry.dependencies]
 python = "^3.8"
 
-visier.sdk.core.api = "= {{packageVersion}}"
+{{corePackageName}} = "~= {{packageVersion}}"
 
 [tool.poetry.dev-dependencies]
 pytest = ">=7.2.1"

--- a/sdk-blueprints/python/api/templates/requirements.mustache
+++ b/sdk-blueprints/python/api/templates/requirements.mustache
@@ -1,1 +1,1 @@
-visier.sdk.api.core == {{packageVersion}}
+{{corePackageName}} ~= {{packageVersion}}

--- a/sdk-blueprints/python/api/templates/setup.mustache
+++ b/sdk-blueprints/python/api/templates/setup.mustache
@@ -17,7 +17,7 @@ PYTHON_REQUIRES = ">=3.8"
 {{#apis}}
 {{#-last}}
 REQUIRES = [
-    "visier.sdk.api.core == {{packageVersion}}",
+    "{{corePackageName}} ~= {{packageVersion}}",
 ]
 
 setup(

--- a/sdk-blueprints/python/api/templates/tox.mustache
+++ b/sdk-blueprints/python/api/templates/tox.mustache
@@ -4,7 +4,7 @@ envlist = py38
 [testenv]
 deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
-     ../visier.sdk.api.core
+     ../{{corePackageName}}
 
 commands=
    pytest --cov={{{packageName}}}

--- a/sdk-blueprints/python/core/.openapi-generator-ignore
+++ b/sdk-blueprints/python/core/.openapi-generator-ignore
@@ -2,8 +2,8 @@
 docs/
 .github/
 test/
-visier/sdk/api/core/api/
-visier/sdk/api/core/models/
+visier_api*/api/
+visier_api*/models/
 
 # Ignore files in the root by default
 /*

--- a/sdk-blueprints/python/core/templates/__init__package.mustache
+++ b/sdk-blueprints/python/core/templates/__init__package.mustache
@@ -10,8 +10,8 @@ __version__ = "{{packageVersion}}"
 from {{packageName}}.api_response import ApiResponse
 from {{packageName}}.api_client import ApiClient, RequestSerialized
 from {{packageName}}.configuration import Configuration
-from {{corePackageName}}.rest import RESTClientObject, RESTResponseType
-from {{corePackageName}}.exceptions import OpenApiException, ApiTypeError, ApiValueError, ApiKeyError, ApiAttributeError, ApiException
+from {{corePackageModule}}.rest import RESTClientObject, RESTResponseType
+from {{corePackageModule}}.exceptions import OpenApiException, ApiTypeError, ApiValueError, ApiKeyError, ApiAttributeError, ApiException
 {{#hasHttpSignatureMethods}}
 from {{packageName}}.signing import HttpSigningConfiguration
 {{/hasHttpSignatureMethods}}

--- a/sdk-blueprints/python/core/templates/api_client.mustache
+++ b/sdk-blueprints/python/core/templates/api_client.mustache
@@ -19,10 +19,10 @@ from pydantic import SecretStr
 import tornado.gen
 {{/tornado}}
 
-from {{corePackageName}}.configuration import Configuration
-from {{corePackageName}}.api_response import ApiResponse, T as ApiResponseT
-from {{corePackageName}} import rest
-from {{corePackageName}}.exceptions import (
+from {{corePackageModule}}.configuration import Configuration
+from {{corePackageModule}}.api_response import ApiResponse, T as ApiResponseT
+from {{corePackageModule}} import rest
+from {{corePackageModule}}.exceptions import (
     ApiValueError,
     ApiException,
     BadRequestException,

--- a/sdk-blueprints/python/core/templates/configuration.mustache
+++ b/sdk-blueprints/python/core/templates/configuration.mustache
@@ -24,7 +24,7 @@ import urllib3
 from flask import Flask, request
 from pydantic import BaseModel
 
-from {{corePackageName}}.exceptions import ApiException
+from {{corePackageModule}}.exceptions import ApiException
 
 {{^asyncio}}
 import multiprocessing

--- a/sdk-blueprints/python/core/templates/rest.mustache
+++ b/sdk-blueprints/python/core/templates/rest.mustache
@@ -9,7 +9,7 @@ import ssl
 
 import urllib3
 
-from {{corePackageName}}.exceptions import ApiException, ApiValueError
+from {{corePackageModule}}.exceptions import ApiException, ApiValueError
 
 SUPPORTED_SOCKS_PROXIES = {"socks5", "socks5h", "socks4", "socks4a"}
 RESTResponseType = urllib3.HTTPResponse

--- a/sdk-blueprints/python/generate-all.sh
+++ b/sdk-blueprints/python/generate-all.sh
@@ -16,8 +16,8 @@ fi
 # Get the directory of the current script
 script_dir=$(dirname "$0")
 
-"$script_dir"/generate-package.sh visier.sdk.api.core "$spec_dir/authentication-apis.yaml" sdk-blueprints/python/core "$output_dir"
-"$script_dir"/generate-package.sh visier.sdk.api.analytic_model "$spec_dir/analytic-model-apis.yaml" sdk-blueprints/python/api "$output_dir"
-"$script_dir"/generate-package.sh visier.sdk.api.administration "$spec_dir/administration-apis.yaml" sdk-blueprints/python/api "$output_dir"
-"$script_dir"/generate-package.sh visier.sdk.api.data_in "$spec_dir/data-in-apis.yaml" sdk-blueprints/python/api "$output_dir"
-"$script_dir"/generate-package.sh visier.sdk.api.data_out "$spec_dir/data-out-apis.yaml" sdk-blueprints/python/api "$output_dir"
+"$script_dir"/generate-package.sh visier_api_core "$spec_dir/authentication-apis.yaml" sdk-blueprints/python/core "$output_dir"
+"$script_dir"/generate-package.sh visier_api_analytic_model "$spec_dir/analytic-model-apis.yaml" sdk-blueprints/python/api "$output_dir"
+"$script_dir"/generate-package.sh visier_api_administration "$spec_dir/administration-apis.yaml" sdk-blueprints/python/api "$output_dir"
+"$script_dir"/generate-package.sh visier_api_data_in "$spec_dir/data-in-apis.yaml" sdk-blueprints/python/api "$output_dir"
+"$script_dir"/generate-package.sh visier_api_data_out "$spec_dir/data-out-apis.yaml" sdk-blueprints/python/api "$output_dir"

--- a/sdk-blueprints/python/generate-package.sh
+++ b/sdk-blueprints/python/generate-package.sh
@@ -43,4 +43,4 @@ openapi-generator-cli generate \
   --package-name "$package_name" \
   -o "$output_api_dir" \
   --skip-validate-spec \
-  --additional-properties=packageVersion="$spec_version",corePackageName="visier.sdk.api.core"
+  --additional-properties=packageVersion="$spec_version",corePackageModule="visier_api_core",corePackageName="visier-api-core"

--- a/sdk-blueprints/python/run-tests.sh
+++ b/sdk-blueprints/python/run-tests.sh
@@ -20,7 +20,7 @@ while IFS= read -r dir; do
     error_flag=1
   fi
   cd - > /dev/null
-done < <(find "$SEARCH_PATH" -type d -name "visier.sdk.api*" -print)
+done < <(find "$SEARCH_PATH" -type d -name "visier-api*" -print)
 
 # Exit with the error flag status
 exit $error_flag


### PR DESCRIPTION
The current package naming convention, such as visier.sdk.api.core and visier.sdk.api.data-in, poses challenges with module resolving. This is because all packages are installed in the same folder structure, for example, visier/sdk/api/.... These issues manifest in various scenarios:
Difficulty in name resolution when running local tests.
Name conflicts arise when installing multiple packages with similar names within a single project.
Potential conflicts may emerge if additional libraries adopt the visier.sdk. prefix in the future.
To mitigate this concern effectively in Python, it's recommended to employ unique names by using a hyphen ('-') as a separator within package names. There is no necessity to include sdk in the name anymore; henceforth, future package names will be formatted as follows:
visier-api-core
visier-api-data-in
visier-api-data-out