### PR TITLE
[VAN-128120] Ignore incorrectly generated unit test for oneOf DTO.

### DIFF
--- a/sdk-blueprints/python/api/.openapi-generator-ignore
+++ b/sdk-blueprints/python/api/.openapi-generator-ignore
@@ -6,6 +6,9 @@ docs/
 visier_api*/*.py
 !visier_api*/__init__.py
 
+# Ignore broken unit test for DTO
+test/test_sql_like200_response.py
+
 # Ignore files in the root by default
 /*
 

--- a/sdk-blueprints/python/api/templates/model_oneof.mustache
+++ b/sdk-blueprints/python/api/templates/model_oneof.mustache
@@ -160,7 +160,7 @@ class {{classname}}({{#parent}}{{{.}}}{{/parent}}{{^parent}}BaseModel{{/parent}}
         # deserialize data into {{{dataType}}}
         try:
             actual_instance = {{{dataType}}}.from_json(json_str)
-            if actual_instance != cls._default_values[{{{dataType}}}.__name__]:
+            if actual_instance and actual_instance != cls._default_values[{{{dataType}}}.__name__]:
                 instance.actual_instance = actual_instance
                 match += 1
         except (ValidationError, ValueError) as e:


### PR DESCRIPTION
Additionally, a check was added for the creation of the inner `actual_instance` DTO. If both DTOs are None, a correct exception will be generated.
"No match found when deserializing the JSON string into SqlLike200Response..."