### PR TITLE
[VAN-127639] passed headers instead default

### DIFF
--- a/sdk-blueprints/python/core/templates/api_client.mustache
+++ b/sdk-blueprints/python/core/templates/api_client.mustache
@@ -183,7 +183,6 @@ class ApiClient:
         header_params = header_params or {}
         for key, value in self.default_headers.items():
             header_params.setdefault(key, value)
-
         if self.cookie:
             header_params['Cookie'] = self.cookie
         if header_params:

--- a/sdk-blueprints/python/core/templates/api_client.mustache
+++ b/sdk-blueprints/python/core/templates/api_client.mustache
@@ -181,7 +181,9 @@ class ApiClient:
 
         # header parameters
         header_params = header_params or {}
-        header_params.update(self.default_headers)
+        for key, value in self.default_headers.items():
+            header_params.setdefault(key, value)
+
         if self.cookie:
             header_params['Cookie'] = self.cookie
         if header_params:

--- a/sdk-blueprints/python/core/templates/configuration.mustache
+++ b/sdk-blueprints/python/core/templates/configuration.mustache
@@ -323,14 +323,14 @@ class Configuration:
         """
 
         return Configuration(
-            host=config_dict[VISIER_HOST],
-            api_key=config_dict[VISIER_APIKEY],
-            username=config_dict[VISIER_USERNAME],
-            password=config_dict[VISIER_PASSWORD],
-            client_id=config_dict[VISIER_CLIENT_ID],
-            client_secret=config_dict[VISIER_CLIENT_SECRET],
-            redirect_uri=config_dict[VISIER_REDIRECT_URI],
-            vanity=config_dict[VISIER_VANITY]
+            host=config_dict.get(VISIER_HOST),
+            api_key=config_dict.get(VISIER_APIKEY),
+            username=config_dict.get(VISIER_USERNAME),
+            password=config_dict.get(VISIER_PASSWORD),
+            client_id=config_dict.get(VISIER_CLIENT_ID),
+            client_secret=config_dict.get(VISIER_CLIENT_SECRET),
+            redirect_uri=config_dict.get(VISIER_REDIRECT_URI),
+            vanity=config_dict.get(VISIER_VANITY)
         )
 
     @staticmethod


### PR DESCRIPTION
The client will now use the provided `headers` instead of replacing them with `default_headers`.

The `from_dict` method of the creation configuration has been fixed to prevent exceptions if some keys are missing from the dictionary. The host can be set outside `Configuration.py`, even if it is not present in the dictionary.