### PR TITLE
Added permissions so API Ref workflow can create releases

### DIFF
--- a/.github/workflows/build-api-ref.yml
+++ b/.github/workflows/build-api-ref.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   generate-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write  # Add permissions for writing content (creating releases)
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Currently, the API Ref documentation generation workflow is missing permissions to generate the releases, so this grants it the perms it needs to do releases and create artifacts.