### PR TITLE
Revert combine process order

### DIFF
--- a/redocly/scripts/combine_yamls.py
+++ b/redocly/scripts/combine_yamls.py
@@ -9,8 +9,8 @@ FILE_PATHS = {
     "data_out": "../res/data-out-apis.yaml",
     "administration": "../res/administration-apis.yaml",
     "analytic_model": "../res/analytic-model-apis.yaml",
-    "compensation_benchmarks": "../res/compensation-benchmarks.yaml",
-    "skills_intelligence": "../res/skills-intelligence-engine.yaml"
+    "skills_intelligence": "../res/skills-intelligence-engine.yaml",
+    "compensation_benchmarks": "../res/compensation-benchmarks.yaml"
     }
 
 EXCLUDED_TAGS = {}
@@ -97,7 +97,7 @@ def merge_openapi_components(collected_data):
     }
 
     openapi_merged = {
-        "openapi": "3.0.0",
+        "openapi": "3.0.3",
         "info": {
             "title": "API Reference",
             "description": "Detailed API reference documentation for Visier APIs. Includes all endpoints, headers, path parameters, query parameters, request body schema, response schema, JSON request samples, and JSON response samples."

--- a/redocly/scripts/combine_yamls_test.py
+++ b/redocly/scripts/combine_yamls_test.py
@@ -92,7 +92,7 @@ def test_merge_openapi_components():
         "x-tagGroups": {"Test Group": {"name": "Test Group", "tags": ["SomeTag"]}},
     }
     merged_data = merge_openapi_components(collected_data)
-    assert merged_data["openapi"] == "3.0.0"
+    assert merged_data["openapi"] == "3.0.3"
     assert merged_data["paths"] == collected_data["paths"]
     assert merged_data["components"]["schemas"] == collected_data["schemas"]
     assert merged_data["components"]["securitySchemes"] == collected_data["securitySchemes"]


### PR DESCRIPTION
The compensation benchmark file has to be processed after skills as otherwise the output gets corrupt. This fix doesn't deal with the root cause of that issue (corruption shouldn't happen for any file order), but we need to be able to generate correct documentation so the revert is the quickest fix.

Also, bumped the OAS3 version from 3.0.0 to 3.0.3, which is the version we generate. The combined result had the wrong version in it