### PR TITLE
Redocly adjustments

### DIFF
--- a/redocly/redocly.yaml
+++ b/redocly/redocly.yaml
@@ -49,7 +49,7 @@ theme:
         fontSize: 'inherit'
         headings:
           fontFamily: 'inherit'
-          fontSize: 'inherit'
         code: 
           color: '#000000'
+          fontSize: 'inherit'
           wrap: true

--- a/redocly/redocly.yaml
+++ b/redocly/redocly.yaml
@@ -46,8 +46,10 @@ theme:
         backgroundColor: '#334155'
       typography:
         fontFamily: 'inherit'
+        fontSize: 'inherit'
         headings:
           fontFamily: 'inherit'
+          fontSize: 'inherit'
         code: 
           color: '#000000'
           wrap: true


### PR DESCRIPTION
Adjusting the redocly configuration we use to generate the documentation so that font sizes are inherited from parent elements rather than using the redocly defaults of `14px` and `13px` for code blocks.