### PR TITLE
Fix naming conflicts between Compensation Benchmarks and Skills Intelligence Engine schemas

### DIFF
--- a/redocly/scripts/combine_yamls.py
+++ b/redocly/scripts/combine_yamls.py
@@ -147,7 +147,7 @@ def merge_elements(collected_data: dict, element_name: str) -> dict:
 
     if problematic_elements:
         msg = [contents for contents in problematic_elements.values()]
-        raise ValueError(f"{len(msg)} conflicting {element_name} entries:\n" + "\n".join(msg))
+        raise ValueError(f"{len(msg)} conflicting {element_name} entries:\n" + "\n===\n".join(msg))
 
     return merged_elements
 

--- a/redocly/scripts/combine_yamls.py
+++ b/redocly/scripts/combine_yamls.py
@@ -4,21 +4,10 @@ import re
 import yaml
 
 # Paths to the API spec files to combine
-DA_FILE_PATHS = {
-    "skills_intelligence": "../res/skills-intelligence-engine.yaml",
-    "compensation_benchmarks": "../res/compensation-benchmarks.yaml",
-}
-LEGACY_FILE_PATHS = {
-    "authentication": "../res/authentication-apis.yaml",
-    "data_in": "../res/data-in-apis.yaml",
-    "data_out": "../res/data-out-apis.yaml",
-    "administration": "../res/administration-apis.yaml",
-    "analytic_model": "../res/analytic-model-apis.yaml",
-    **DA_FILE_PATHS
-}
 FILE_PATHS = {
     "visier-apis": "../res/visier-apis.yaml",
-    **DA_FILE_PATHS
+    "skills_intelligence": "../res/skills-intelligence-engine.yaml",
+    "compensation_benchmarks": "../res/compensation-benchmarks.yaml",
 }
 
 EXCLUDED_TAGS = {}
@@ -177,17 +166,12 @@ def merge_openapi_components(collected_data):
 
 
 if __name__ == '__main__':
+    merged_yaml_path = 'master_api_combined.yaml'
 
-    combine_sets = {
-        'master_api_combined.yaml': FILE_PATHS,
-        'master_api_combined_legacy.yaml': LEGACY_FILE_PATHS,
-    }
+    collected_data = collect_openapi_components(FILE_PATHS, EXCLUDED_TAGS)
+    openapi_combined = merge_openapi_components(collected_data)
 
-    for merged_yaml_path, file_paths in combine_sets.items():
-        collected_data = collect_openapi_components(file_paths, EXCLUDED_TAGS)
-        openapi_combined = merge_openapi_components(collected_data)
+    with open(merged_yaml_path, 'w') as yaml_file:
+        yaml.dump(openapi_combined, yaml_file, sort_keys=False)
 
-        with open(merged_yaml_path, 'w') as yaml_file:
-            yaml.dump(openapi_combined, yaml_file, sort_keys=False)
-
-        print(f"Merged OpenAPI YAML saved to {merged_yaml_path}")
+    print(f"Merged OpenAPI YAML saved to {merged_yaml_path}")

--- a/redocly/scripts/combine_yamls.py
+++ b/redocly/scripts/combine_yamls.py
@@ -78,7 +78,9 @@ def collect_openapi_components(FILE_PATHS, EXCLUDED_TAGS):
         collected_data["securitySchemes"][group_name] = security_schemes
 
         tags = parsed_content.get('tags', [])
+        tag_groups = parsed_content.get('x-tagGroups', [])
         for tag in tags:
+
             if group_name in EXCLUDED_TAGS and tag['name'] in EXCLUDED_TAGS[group_name]:
                 continue
 
@@ -87,7 +89,7 @@ def collect_openapi_components(FILE_PATHS, EXCLUDED_TAGS):
             tag['x-displayName'] = display_name
             collected_data["tags"][original_tag_name] = tag
 
-            group_name_transformed = transform_tag_group_name(group_name)
+            group_name_transformed = [tg['name'] for tg in tag_groups if original_tag_name in tg['tags']][0] if tag_groups else transform_tag_group_name(group_name)
             if group_name_transformed not in collected_data["x-tagGroups"]:
                 collected_data["x-tagGroups"][group_name_transformed] = {"name": group_name_transformed, "tags": []}
 

--- a/redocly/scripts/combine_yamls.py
+++ b/redocly/scripts/combine_yamls.py
@@ -146,11 +146,13 @@ def merge_openapi_components(collected_data):
 
     return openapi_merged
 
-collected_data = collect_openapi_components(FILE_PATHS, EXCLUDED_TAGS)
-openapi_combined = merge_openapi_components(collected_data)
 
-merged_yaml_path = 'master_api_combined.yaml'
-with open(merged_yaml_path, 'w') as yaml_file:
-    yaml.dump(openapi_combined, yaml_file, sort_keys=False)
+if __name__ == '__main__':
+    collected_data = collect_openapi_components(FILE_PATHS, EXCLUDED_TAGS)
+    openapi_combined = merge_openapi_components(collected_data)
 
-print(f"Merged OpenAPI YAML saved to {merged_yaml_path}")
+    merged_yaml_path = 'master_api_combined.yaml'
+    with open(merged_yaml_path, 'w') as yaml_file:
+        yaml.dump(openapi_combined, yaml_file, sort_keys=False)
+
+    print(f"Merged OpenAPI YAML saved to {merged_yaml_path}")

--- a/redocly/scripts/combine_yamls.py
+++ b/redocly/scripts/combine_yamls.py
@@ -16,7 +16,7 @@ LEGACY_FILE_PATHS = {
     **DA_FILE_PATHS
 }
 FILE_PATHS = {
-    "everything": "../res/everything.yaml",
+    "visier-apis": "../res/visier-apis.yaml",
     **DA_FILE_PATHS
 }
 

--- a/redocly/scripts/combine_yamls.py
+++ b/redocly/scripts/combine_yamls.py
@@ -3,15 +3,22 @@ import re
 import os
 
 # Paths to the API spec files to combine
-FILE_PATHS = {
+DA_FILE_PATHS = {
+    "skills_intelligence": "../res/skills-intelligence-engine.yaml",
+    "compensation_benchmarks": "../res/compensation-benchmarks.yaml",
+}
+LEGACY_FILE_PATHS = {
     "authentication": "../res/authentication-apis.yaml",
     "data_in": "../res/data-in-apis.yaml",
     "data_out": "../res/data-out-apis.yaml",
     "administration": "../res/administration-apis.yaml",
     "analytic_model": "../res/analytic-model-apis.yaml",
-    "skills_intelligence": "../res/skills-intelligence-engine.yaml",
-    "compensation_benchmarks": "../res/compensation-benchmarks.yaml"
-    }
+    **DA_FILE_PATHS
+}
+FILE_PATHS = {
+    "everything": "../res/everything.yaml",
+    **DA_FILE_PATHS
+}
 
 EXCLUDED_TAGS = {}
 
@@ -148,11 +155,17 @@ def merge_openapi_components(collected_data):
 
 
 if __name__ == '__main__':
-    collected_data = collect_openapi_components(FILE_PATHS, EXCLUDED_TAGS)
-    openapi_combined = merge_openapi_components(collected_data)
 
-    merged_yaml_path = 'master_api_combined.yaml'
-    with open(merged_yaml_path, 'w') as yaml_file:
-        yaml.dump(openapi_combined, yaml_file, sort_keys=False)
+    combine_sets = {
+        'master_api_combined.yaml': FILE_PATHS,
+        'master_api_combined_legacy.yaml': LEGACY_FILE_PATHS,
+    }
 
-    print(f"Merged OpenAPI YAML saved to {merged_yaml_path}")
+    for merged_yaml_path, file_paths in combine_sets.items():
+        collected_data = collect_openapi_components(file_paths, EXCLUDED_TAGS)
+        openapi_combined = merge_openapi_components(collected_data)
+
+        with open(merged_yaml_path, 'w') as yaml_file:
+            yaml.dump(openapi_combined, yaml_file, sort_keys=False)
+
+        print(f"Merged OpenAPI YAML saved to {merged_yaml_path}")

--- a/redocly/scripts/combine_yamls.py
+++ b/redocly/scripts/combine_yamls.py
@@ -9,8 +9,8 @@ FILE_PATHS = {
     "data_out": "../res/data-out-apis.yaml",
     "administration": "../res/administration-apis.yaml",
     "analytic_model": "../res/analytic-model-apis.yaml",
-    "compensation_benchmarks": "../res/compensation-benchmarks.yaml",
     "skills_intelligence": "../res/skills-intelligence-engine.yaml",
+    "compensation_benchmarks": "../res/compensation-benchmarks.yaml"
     }
 
 EXCLUDED_TAGS = {}

--- a/redocly/scripts/combine_yamls_test.py
+++ b/redocly/scripts/combine_yamls_test.py
@@ -69,13 +69,15 @@ def test_collect_openapi_components():
     with open("temp_test.yaml", "w") as f:
         f.write(SAMPLE_YAML_CONTENT)
 
-    file_paths = {"test_group": "temp_test.yaml"}
+    group_name = "test_group"
+
+    file_paths = {group_name: "temp_test.yaml"}
     excluded_tags = {}
     collected_data = collect_openapi_components(file_paths, excluded_tags)
 
     assert "/some/path" in collected_data["paths"]
-    assert "SomeSchema" in collected_data["schemas"]
-    assert "SomeSecurityScheme" in collected_data["securitySchemes"]
+    assert "SomeSchema" in collected_data["schemas"][group_name]
+    assert "SomeSecurityScheme" in collected_data["securitySchemes"][group_name]
     assert "SomeTag" in collected_data["tags"]
 
     # Clean up the temporary file
@@ -86,15 +88,25 @@ def test_collect_openapi_components():
 def test_merge_openapi_components():
     collected_data = {
         "paths": {"/some/path": {"get": {"summary": "Some summary"}}},
-        "schemas": {"SomeSchema": {"type": "object"}},
-        "securitySchemes": {"SomeSecurityScheme": {"type": "apiKey"}},
+        "schemas": {"test_group": {"SomeSchema": {"type": "object"}}},
+        "securitySchemes": {"test_group": {"SomeSecurityScheme": {"type": "apiKey"}}},
         "tags": {"SomeTag": {"name": "SomeTag"}},
         "x-tagGroups": {"Test Group": {"name": "Test Group", "tags": ["SomeTag"]}},
     }
     merged_data = merge_openapi_components(collected_data)
     assert merged_data["openapi"] == "3.0.3"
     assert merged_data["paths"] == collected_data["paths"]
-    assert merged_data["components"]["schemas"] == collected_data["schemas"]
-    assert merged_data["components"]["securitySchemes"] == collected_data["securitySchemes"]
+    assert merged_data["components"]["schemas"] == collected_data["schemas"]["test_group"]
+    assert merged_data["components"]["securitySchemes"] == collected_data["securitySchemes"]["test_group"]
     assert merged_data["tags"] == list(collected_data["tags"].values())
     assert merged_data["x-tagGroups"] == list(collected_data["x-tagGroups"].values())
+
+
+if __name__ == '__main__':
+    test_transform_tag_name()
+    test_transform_tag_group_name()
+    test_replace_br_tags()
+    test_escape_ampersands()
+    test_process_descriptions()
+    test_collect_openapi_components()
+    test_merge_openapi_components()

--- a/redocly/scripts/combine_yamls_test.py
+++ b/redocly/scripts/combine_yamls_test.py
@@ -1,4 +1,7 @@
+import unittest
 import yaml
+
+
 from combine_yamls import (
     transform_tag_name,
     transform_tag_group_name,
@@ -9,104 +12,169 @@ from combine_yamls import (
     merge_openapi_components,
 )
 
-# Sample YAML content for testing
-SAMPLE_YAML_CONTENT = """
-paths:
-  /some/path:
-    get:
-      summary: Some summary
-      description: Some description with <br> tags
-      tags:
-        - SomeTag
-components:
-  schemas:
-    SomeSchema:
-      type: object
-      properties:
-        someProperty:
-          type: string
-  securitySchemes:
-    SomeSecurityScheme:
-      type: apiKey
-      in: header
-      name: X-API-Key
-tags:
-  - name: SomeTag
-    description: Some tag description with & unescaped
-"""
 
+class CombineYamlTests(unittest.TestCase):
 
-def test_transform_tag_name():
-    assert transform_tag_name("SomeTagName") == "Some Tag Name"
-    assert transform_tag_name("AnotherTagName") == "Another Tag Name"
+    # Sample YAML content for testing
+    SAMPLE_YAML_CONTENT = """
+    paths:
+      /some/path:
+        get:
+          summary: Some summary
+          description: Some description with <br> tags
+          tags:
+            - SomeTag
+    components:
+      schemas:
+        SomeSchema:
+          type: object
+          properties:
+            someProperty:
+              type: string
+      securitySchemes:
+        SomeSecurityScheme:
+          type: apiKey
+          in: header
+          name: X-API-Key
+    tags:
+      - name: SomeTag
+        description: Some tag description with & unescaped
+    """
 
+    def test_transform_tag_name(self):
+        assert transform_tag_name("SomeTagName") == "Some Tag Name"
+        assert transform_tag_name("AnotherTagName") == "Another Tag Name"
 
-def test_transform_tag_group_name():
-    assert transform_tag_group_name("some_group") == "some group"
-    assert transform_tag_group_name("another_group") == "another group"
+    def test_transform_tag_group_name(self):
+        assert transform_tag_group_name("some_group") == "some group"
+        assert transform_tag_group_name("another_group") == "another group"
 
+    def test_replace_br_tags(self):
+        assert replace_br_tags("Some text with <br> tags") == "Some text with <br/> tags"
+        assert replace_br_tags("Some text without br tags") == "Some text without br tags"
 
-def test_replace_br_tags():
-    assert replace_br_tags("Some text with <br> tags") == "Some text with <br/> tags"
-    assert replace_br_tags("Some text without br tags") == "Some text without br tags"
+    def test_escape_ampersands(self):
+        assert escape_ampersands("Some text with & unescaped") == "Some text with &amp; unescaped"
+        assert escape_ampersands("Some text with &amp; escaped") == "Some text with &amp; escaped"
+        assert escape_ampersands("Some text with &lt; &gt; &quot; &apos;") == "Some text with &lt; &gt; &quot; &apos;"
 
+    def test_process_descriptions(self):
+        data = yaml.safe_load(self.SAMPLE_YAML_CONTENT)
+        process_descriptions(data)
+        assert data["paths"]["/some/path"]["get"]["description"] == "Some description with <br/> tags"
+        assert data["tags"][0]["description"] == "Some tag description with &amp; unescaped"
 
-def test_escape_ampersands():
-    assert escape_ampersands("Some text with & unescaped") == "Some text with &amp; unescaped"
-    assert escape_ampersands("Some text with &amp; escaped") == "Some text with &amp; escaped"
-    assert escape_ampersands("Some text with &lt; &gt; &quot; &apos;") == "Some text with &lt; &gt; &quot; &apos;"
+    def test_collect_openapi_components(self):
+        # Create a temporary YAML file for testing
+        with open("temp_test.yaml", "w") as f:
+            f.write(self.SAMPLE_YAML_CONTENT)
 
+        group_name = "test_group"
 
-def test_process_descriptions():
-    data = yaml.safe_load(SAMPLE_YAML_CONTENT)
-    process_descriptions(data)
-    assert data["paths"]["/some/path"]["get"]["description"] == "Some description with <br/> tags"
-    assert data["tags"][0]["description"] == "Some tag description with &amp; unescaped"
+        file_paths = {group_name: "temp_test.yaml"}
+        excluded_tags = {}
+        collected_data = collect_openapi_components(file_paths, excluded_tags)
 
+        assert "/some/path" in collected_data["paths"]
+        assert "SomeSchema" in collected_data["schemas"][group_name]
+        assert "SomeSecurityScheme" in collected_data["securitySchemes"][group_name]
+        assert "SomeTag" in collected_data["tags"]
 
-def test_collect_openapi_components():
-    # Create a temporary YAML file for testing
-    with open("temp_test.yaml", "w") as f:
-        f.write(SAMPLE_YAML_CONTENT)
+        # Clean up the temporary file
+        import os
+        os.remove("temp_test.yaml")
 
-    group_name = "test_group"
+    def test_merge_openapi_components(self):
+        collected_data = {
+            "paths": {"/some/path": {"get": {"summary": "Some summary"}}},
+            "schemas": {"test_group": {"SomeSchema": {"type": "object"}}},
+            "securitySchemes": {"test_group": {"SomeSecurityScheme": {"type": "apiKey"}}},
+            "tags": {"SomeTag": {"name": "SomeTag"}},
+            "x-tagGroups": {"Test Group": {"name": "Test Group", "tags": ["SomeTag"]}},
+        }
+        merged_data = merge_openapi_components(collected_data)
+        assert merged_data["openapi"] == "3.0.3"
+        assert merged_data["paths"] == collected_data["paths"]
+        assert merged_data["components"]["schemas"] == collected_data["schemas"]["test_group"]
+        assert merged_data["components"]["securitySchemes"] == collected_data["securitySchemes"]["test_group"]
+        assert merged_data["tags"] == list(collected_data["tags"].values())
+        assert merged_data["x-tagGroups"] == list(collected_data["x-tagGroups"].values())
 
-    file_paths = {group_name: "temp_test.yaml"}
-    excluded_tags = {}
-    collected_data = collect_openapi_components(file_paths, excluded_tags)
+    def test_merge_openapi_components_multi_group(self):
+        """ Test for schemas and security schemes with multiple declarations of the same object that match in definition resolves correctly """
+        collected_data = {
+            "paths": {"/some/path": {"get": {"summary": "Some summary"}}},
+            "schemas": {
+                "test_group": {
+                    "SomeSchema": {"type": "object"}
+                },
+                "test_group_2": {
+                    "SomeSchema": {"type": "object"}
+                },
+                "test_group_3": {
+                    "SomeSchema": {"type": "object"},
+                    "OtherSchema": {"type": "object"}
+                },
+            },
+            "securitySchemes": {
+                "test_group": {
+                    "SomeSecurityScheme": {"type": "apiKey"}
+                },
+                "test_group_2": {
+                    "SomeSecurityScheme": {"type": "apiKey"}
+                },
+                "test_group_3": {
+                    "SomeSecurityScheme": {"type": "apiKey"},
+                    "OtherSecurityScheme": {"type": "apiKey"}
+                },
+            },
+            "tags": {"SomeTag": {"name": "SomeTag"}},
+            "x-tagGroups": {"Test Group": {"name": "Test Group", "tags": ["SomeTag"]}},
+        }
+        merged_data = merge_openapi_components(collected_data)
+        assert merged_data["openapi"] == "3.0.3"
+        assert merged_data["paths"] == collected_data["paths"]
+        assert merged_data["components"]["schemas"] == collected_data["schemas"]["test_group_3"]
+        assert merged_data["components"]["securitySchemes"] == collected_data["securitySchemes"]["test_group_3"]
+        assert merged_data["tags"] == list(collected_data["tags"].values())
+        assert merged_data["x-tagGroups"] == list(collected_data["x-tagGroups"].values())
 
-    assert "/some/path" in collected_data["paths"]
-    assert "SomeSchema" in collected_data["schemas"][group_name]
-    assert "SomeSecurityScheme" in collected_data["securitySchemes"][group_name]
-    assert "SomeTag" in collected_data["tags"]
+    def test_merge_openapi_components_schema_conflict(self):
+        """ Test to ensure inconsistent schemas in different groups is detected """
+        collected_data = {
+            "paths": {"/some/path": {"get": {"summary": "Some summary"}}},
+            "schemas": {
+                "test_group": {"SomeSchema": {"type": "object"}},
+                "test_group_2": {"SomeSchema": {"type": "string"}},
+            },
+            "securitySchemes": {
+                "test_group": {"SomeSecurityScheme": {"type": "apiKey"}},
+                "test_group_2": {"SomeSecurityScheme": {"type": "apiKey"}},
+            },
+            "tags": {"SomeTag": {"name": "SomeTag"}},
+            "x-tagGroups": {"Test Group": {"name": "Test Group", "tags": ["SomeTag"]}},
+        }
+        with self.assertRaises(ValueError):
+            merge_openapi_components(collected_data)
 
-    # Clean up the temporary file
-    import os
-    os.remove("temp_test.yaml")
-
-
-def test_merge_openapi_components():
-    collected_data = {
-        "paths": {"/some/path": {"get": {"summary": "Some summary"}}},
-        "schemas": {"test_group": {"SomeSchema": {"type": "object"}}},
-        "securitySchemes": {"test_group": {"SomeSecurityScheme": {"type": "apiKey"}}},
-        "tags": {"SomeTag": {"name": "SomeTag"}},
-        "x-tagGroups": {"Test Group": {"name": "Test Group", "tags": ["SomeTag"]}},
-    }
-    merged_data = merge_openapi_components(collected_data)
-    assert merged_data["openapi"] == "3.0.3"
-    assert merged_data["paths"] == collected_data["paths"]
-    assert merged_data["components"]["schemas"] == collected_data["schemas"]["test_group"]
-    assert merged_data["components"]["securitySchemes"] == collected_data["securitySchemes"]["test_group"]
-    assert merged_data["tags"] == list(collected_data["tags"].values())
-    assert merged_data["x-tagGroups"] == list(collected_data["x-tagGroups"].values())
+    def test_merge_openapi_components_securitySchemes_conflict(self):
+        """ Test to ensure inconsistent security schemes in different groups is detected """
+        collected_data = {
+            "paths": {"/some/path": {"get": {"summary": "Some summary"}}},
+            "schemas": {
+                "test_group": {"SomeSchema": {"type": "object"}},
+                "test_group_2": {"SomeSchema": {"type": "object"}},
+            },
+            "securitySchemes": {
+                "test_group": {"SomeSecurityScheme": {"type": "apiKey"}},
+                "test_group_2": {"SomeSecurityScheme": {"type": "usernamePassword"}},
+            },
+            "tags": {"SomeTag": {"name": "SomeTag"}},
+            "x-tagGroups": {"Test Group": {"name": "Test Group", "tags": ["SomeTag"]}},
+        }
+        with self.assertRaises(ValueError):
+            merge_openapi_components(collected_data)
 
 
 if __name__ == '__main__':
-    test_transform_tag_name()
-    test_transform_tag_group_name()
-    test_replace_br_tags()
-    test_escape_ampersands()
-    test_process_descriptions()
-    test_collect_openapi_components()
-    test_merge_openapi_components()
+    unittest.main()

--- a/res/skills-intelligence-engine.yaml
+++ b/res/skills-intelligence-engine.yaml
@@ -208,7 +208,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JobStandardizationInputSkills"
+              $ref: "#/components/schemas/JobStandardizationInput"
         required: true
       responses:
         "200":
@@ -217,7 +217,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobStandardizationOutputSkills"
+                $ref: "#/components/schemas/JobStandardizationOutput"
         "400":
           description: |
             The API request failed given the parameters provided, such as missing or invalid parameters.
@@ -880,7 +880,7 @@ components:
           - id
           - name
           - description
-    JobStandardizationInputSkills:
+    JobStandardizationInput:
       description: |
         The custom job titles to standardize.
       type: "object"
@@ -897,7 +897,7 @@ components:
             If `naicsCode` is provided, the most relevant job titles associated with the naicsCode are returned first.
       required:
         - "jobs"
-    JobStandardizationOutputSkills:
+    JobStandardizationOutput:
       type: "array"
       items:
         title: OutputEntry

--- a/res/skills-intelligence-engine.yaml
+++ b/res/skills-intelligence-engine.yaml
@@ -9,12 +9,12 @@ info:
   version: "1.0.0"
 
 tags:
-- name: Jobs Library
-  description: |
-    Access over 3,300 standard jobs and get complete details in 27 languages, such as alternative titles, descriptions, and skills.
-- name: Skills Library
-  description: |
-    Access over 14,000 skills and get complete skill details in 27 languages, such as alternative titles, descriptions, and hierarchies.
+  - name: Jobs Library
+    description: |
+      Access over 3,300 standard jobs and get complete details in 27 languages, such as alternative titles, descriptions, and skills.
+  - name: Skills Library
+    description: |
+      Access over 14,000 skills and get complete skill details in 27 languages, such as alternative titles, descriptions, and hierarchies.
 
 paths:
   /v1/jobs/{id}:
@@ -25,23 +25,23 @@ paths:
       description: |
         If you know the ID of a job, use this endpoint to retrieve information such as display name, description, Automation Index, Remote Work Index, alternative names, and skills.
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-        description: |
-          The ID of the job to retrieve details for.
-      - name: "Accept-Language"
-        in: "header"
-        schema:
-          type: "string"
-        description: |
-          Allows you to specify if you want the output to be in one of the accepted languages.
-
-          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-
-          If no value is specified, the response language is English.
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: |
+            The ID of the job to retrieve details for.
+        - name: "Accept-Language"
+          in: "header"
+          schema:
+            type: "string"
+          description: |
+            Allows you to specify if you want the output to be in one of the accepted languages.
+            
+            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+            
+            If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -77,7 +77,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-get-job-arn}"
       security:
-      - api_key: []
+        - api_key: []
   /v1/jobs:
     get:
       summary: Retrieve a list of jobs
@@ -86,16 +86,16 @@ paths:
       description: |
         Use this endpoint to retrieve all the jobs in Visier's Jobs Library.
       parameters:
-      - name: "Accept-Language"
-        in: "header"
-        schema:
-          type: "string"
-        description: |
-          Allows you to specify if you want the output to be in one of the accepted languages.
-
-          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-
-          If no value is specified, the response language is English.
+        - name: "Accept-Language"
+          in: "header"
+          schema:
+            type: "string"
+          description: |
+            Allows you to specify if you want the output to be in one of the accepted languages.
+            
+            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+            
+            If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -131,7 +131,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-list-jobs-arn}"
       security:
-      - api_key: []
+        - api_key: []
   /v1/jobs/search:
     get:
       summary: Search jobs
@@ -140,23 +140,23 @@ paths:
       description: |
         Retrieve a list of jobs that match a specified search term.
       parameters:
-      - name: "term"
-        in: "query"
-        required: true
-        schema:
-          type: "string"
-        description: |
-          The term to search for. The search term must be URL encoded and the minimum length is 3 characters.
-      - name: "Accept-Language"
-        in: "header"
-        schema:
-          type: "string"
-        description: |
-          Allows you to specify if you want the output to be in one of the accepted languages.
-
-          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-
-          If no value is specified, the response language is English.
+        - name: "term"
+          in: "query"
+          required: true
+          schema:
+            type: "string"
+          description: |
+            The term to search for. The search term must be URL encoded and the minimum length is 3 characters.
+        - name: "Accept-Language"
+          in: "header"
+          schema:
+            type: "string"
+          description: |
+            Allows you to specify if you want the output to be in one of the accepted languages.
+            
+            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+            
+            If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -192,7 +192,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-search-job-arn}"
       security:
-      - api_key: []
+        - api_key: []
   /v1/jobs/standardize:
     post:
       summary: Standardize custom job titles
@@ -208,7 +208,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JobStandardizationInput"
+              $ref: "#/components/schemas/JobStandardizationInputSkills"
         required: true
       responses:
         "200":
@@ -217,7 +217,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobStandardizationOutput"
+                $ref: "#/components/schemas/JobStandardizationOutputSkills"
         "400":
           description: |
             The API request failed given the parameters provided, such as missing or invalid parameters.
@@ -245,7 +245,7 @@ paths:
         uri: "${lambda-standardize-job-arn}"
         type: "aws_proxy"
       security:
-      - api_key: []
+        - api_key: []
   /v1/skills/{id}:
     get:
       summary: Get skill details by ID
@@ -254,23 +254,23 @@ paths:
       description: |
         If you know the ID of a skill, use this endpoint to retrieve information such as display name, description, Automation Index, Remote Work Index, and alternative names.
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-        description: |
-          The ID of the skill to retrieve details for.
-      - name: "Accept-Language"
-        in: "header"
-        schema:
-          type: "string"
-        description: |
-          Allows you to specify if you want the output to be in one of the accepted languages.
-
-          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-
-          If no value is specified, the response language is English.
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: |
+            The ID of the skill to retrieve details for.
+        - name: "Accept-Language"
+          in: "header"
+          schema:
+            type: "string"
+          description: |
+            Allows you to specify if you want the output to be in one of the accepted languages.
+            
+            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+            
+            If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -306,7 +306,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-get-skill-arn}"
       security:
-      - api_key: []
+        - api_key: []
   /v1/skills:
     get:
       summary: Retrieve a list of skills
@@ -315,28 +315,28 @@ paths:
       description: |
         Use this endpoint to retrieve all skills in Visier's Skills Library.
       parameters:
-      - name: "skillGroupId"
-        in: "query"
-        schema:
-          type: "string"
-        description: |
-          Filter only skills that belong to a certain skill group.
-      - name: "skillCategoryId"
-        in: "query"
-        schema:
-          type: "string"
-        description: |
-          Filter only skills that belong to a certain skill category.
-      - name: "Accept-Language"
-        in: "header"
-        schema:
-          type: "string"
-        description: |
-          Allows you to specify if you want the output to be in one of the accepted languages.
-
-          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-
-          If no value is specified, the response language is English.
+        - name: "skillGroupId"
+          in: "query"
+          schema:
+            type: "string"
+          description: |
+            Filter only skills that belong to a certain skill group.
+        - name: "skillCategoryId"
+          in: "query"
+          schema:
+            type: "string"
+          description: |
+            Filter only skills that belong to a certain skill category.
+        - name: "Accept-Language"
+          in: "header"
+          schema:
+            type: "string"
+          description: |
+            Allows you to specify if you want the output to be in one of the accepted languages.
+            
+            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+            
+            If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -372,7 +372,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-list-skills-arn}"
       security:
-      - api_key: []
+        - api_key: []
   /v1/skills/search:
     get:
       summary: Search skills
@@ -381,23 +381,23 @@ paths:
       description: |
         Retrieve a list of skills that match a specified search term.
       parameters:
-      - name: "term"
-        in: "query"
-        required: true
-        schema:
-          type: "string"
-        description: |
-          The term to search for. The search term must be URL encoded and the minimum length is 3 characters.
-      - name: "Accept-Language"
-        in: "header"
-        schema:
-          type: "string"
-        description: |
-          Allows you to specify if you want the output to be in one of the accepted languages.
-
-          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-
-          If no value is specified, the response language is English.
+        - name: "term"
+          in: "query"
+          required: true
+          schema:
+            type: "string"
+          description: |
+            The term to search for. The search term must be URL encoded and the minimum length is 3 characters.
+        - name: "Accept-Language"
+          in: "header"
+          schema:
+            type: "string"
+          description: |
+            Allows you to specify if you want the output to be in one of the accepted languages.
+            
+            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+            
+            If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -433,7 +433,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-search-skill-arn}"
       security:
-      - api_key: []
+        - api_key: []
   /v1/skills/extract:
     post:
       summary: Extract skills from text
@@ -442,16 +442,16 @@ paths:
       description: |
         Extract the relevant skills from text such as job descriptions and course outlines.
       parameters:
-      - name: "Accept-Language"
-        in: "header"
-        schema:
-          type: "string"
-        description: |
-          Allows you to specify if you want the output to be in one of the accepted languages.
-          
-          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-          
-          If no value is specified, the response language is English.
+        - name: "Accept-Language"
+          in: "header"
+          schema:
+            type: "string"
+          description: |
+            Allows you to specify if you want the output to be in one of the accepted languages.
+            
+            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+            
+            If no value is specified, the response language is English.
       requestBody:
         description: |
           The text to extract skills from.
@@ -496,7 +496,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-extract-skills-arn}"
       security:
-      - api_key: []
+        - api_key: []
   /v1/skills/match:
     post:
       summary: Match a skill set to a group of skill sets (targets)
@@ -546,7 +546,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-match-skills-arn}"
       security:
-      - api_key: []
+        - api_key: []
   /v1/skill-groups/{id}:
     get:
       summary: Get skill group details by ID
@@ -555,23 +555,23 @@ paths:
       description: |
         If you know the ID of a skill group, use this endpoint to retrieve information such as display name, description, Automation Index, Remote Work Index, and alternative names.
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-        description: |
-          The ID of the skill group to retrieve details for.
-      - name: "Accept-Language"
-        in: "header"
-        schema:
-          type: "string"
-        description: |
-          Allows you to specify if you want the output to be in one of the accepted languages.
-
-          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-
-          If no value is specified, the response language is English.
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: |
+            The ID of the skill group to retrieve details for.
+        - name: "Accept-Language"
+          in: "header"
+          schema:
+            type: "string"
+          description: |
+            Allows you to specify if you want the output to be in one of the accepted languages.
+            
+            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+            
+            If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -607,7 +607,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-get-meta-skill-arn}"
       security:
-      - api_key: []
+        - api_key: []
   /v1/skill-groups:
     get:
       summary: Retrieve a list of skill groups
@@ -616,22 +616,22 @@ paths:
       description: |
         Use this endpoint to retrieve all skill groups in Visier's Skills Library.
       parameters:
-      - name: "skillCategoryId"
-        in: "query"
-        schema:
-          type: "string"
-        description: |
-          Filter only skills that belong to a certain skill category.
-      - name: "Accept-Language"
-        in: "header"
-        schema:
-          type: "string"
-        description: |
-          Allows you to specify if you want the output to be in one of the accepted languages.
-
-          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-
-          If no value is specified, the response language is English.
+        - name: "skillCategoryId"
+          in: "query"
+          schema:
+            type: "string"
+          description: |
+            Filter only skills that belong to a certain skill category.
+        - name: "Accept-Language"
+          in: "header"
+          schema:
+            type: "string"
+          description: |
+            Allows you to specify if you want the output to be in one of the accepted languages.
+            
+            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+            
+            If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -667,7 +667,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-list-meta-skills-arn}"
       security:
-      - api_key: []
+        - api_key: []
   /v1/skill-categories/{id}:
     get:
       summary: Get skill category details by ID
@@ -676,23 +676,23 @@ paths:
       description: |
         If you know the ID of a skill category, use this endpoint to retrieve information such as display name, description, Automation Index, Remote Work Index, and alternative names.
       parameters:
-      - name: "id"
-        in: "path"
-        required: true
-        schema:
-          type: "string"
-        description: |
-          The ID of the skill category to retrieve details for.
-      - name: "Accept-Language"
-        in: "header"
-        schema:
-          type: "string"
-        description: |
-          Allows you to specify if you want the output to be in one of the accepted languages.
-
-          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-
-          If no value is specified, the response language is English.
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+          description: |
+            The ID of the skill category to retrieve details for.
+        - name: "Accept-Language"
+          in: "header"
+          schema:
+            type: "string"
+          description: |
+            Allows you to specify if you want the output to be in one of the accepted languages.
+            
+            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+            
+            If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -728,7 +728,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-get-super-skill-arn}"
       security:
-      - api_key: []
+        - api_key: []
   /v1/skill-categories:
     get:
       summary: Retrieve a list of skill categories
@@ -737,16 +737,16 @@ paths:
       description: |
         Use this endpoint to retrieve all skill categories in Visier's Skills Library.
       parameters:
-      - name: "Accept-Language"
-        in: "header"
-        schema:
-          type: "string"
-        description: |
-          Allows you to specify if you want the output to be in one of the accepted languages.
-
-          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-
-          If no value is specified, the response language is English.
+        - name: "Accept-Language"
+          in: "header"
+          schema:
+            type: "string"
+          description: |
+            Allows you to specify if you want the output to be in one of the accepted languages.
+            
+            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+            
+            If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -782,7 +782,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-list-super-skills-arn}"
       security:
-      - api_key: []
+        - api_key: []
 
 components:
   securitySchemes:
@@ -818,9 +818,9 @@ components:
         socCode:
           type: "string"
           description: |
-           The Standard Occupational Classification (SOC) code of the job.
-
-           This field will be omitted if the job is not associated with a SOC code.
+            The Standard Occupational Classification (SOC) code of the job.
+            
+            This field will be omitted if the job is not associated with a SOC code.
         alternativeTitles:
           type: "array"
           items:
@@ -852,12 +852,12 @@ components:
 
             This field will be omitted if automation is not applicable to the job.
       required:
-      - "id"
-      - "name"
-      - "description"
-      - "alternativeTitles"
-      - "essentialSkills"
-      - "optionalSkills"
+        - "id"
+        - "name"
+        - "description"
+        - "alternativeTitles"
+        - "essentialSkills"
+        - "optionalSkills"
     JobList:
       type: "array"
       items:
@@ -877,10 +877,10 @@ components:
             description: |
               The localized description of the job.
         required:
-        - id
-        - name
-        - description
-    JobStandardizationInput:
+          - id
+          - name
+          - description
+    JobStandardizationInputSkills:
       description: |
         The custom job titles to standardize.
       type: "object"
@@ -896,8 +896,8 @@ components:
             
             If `naicsCode` is provided, the most relevant job titles associated with the naicsCode are returned first.
       required:
-      - "jobs"
-    JobStandardizationOutput:
+        - "jobs"
+    JobStandardizationOutputSkills:
       type: "array"
       items:
         title: OutputEntry
@@ -931,13 +931,13 @@ components:
                   description: |
                     The score representing the confidence level of the match between the standardized job and the custom job title input. The score ranges from 0 to 100.
               required:
-              - id
-              - name
-              - description
-              - score
+                - id
+                - name
+                - description
+                - score
         required:
-        - job
-        - matches
+          - job
+          - matches
     Skill:
       description: |
         The details describing a skill.
@@ -962,7 +962,7 @@ components:
         skillCategoryId:
           type: "string"
           description: |
-            ID of the skill category that this skill belongs to. 
+            ID of the skill category that this skill belongs to.
         isKnowledge:
           type: "boolean"
           description: |
@@ -990,14 +990,14 @@ components:
 
             This field will be omitted if automation is not applicable to the skill.
       required:
-      - "id"
-      - "name"
-      - "description"
-      - "skillGroupId"
-      - "skillCategoryId"
-      - "isKnowledge"
-      - "skillType"
-      - "alternativeTitles"
+        - "id"
+        - "name"
+        - "description"
+        - "skillGroupId"
+        - "skillCategoryId"
+        - "isKnowledge"
+        - "skillType"
+        - "alternativeTitles"
     SkillList:
       type: "array"
       items:
@@ -1017,9 +1017,9 @@ components:
             description: |
               The localized description of the skill.
         required:
-        - id
-        - name
-        - description
+          - id
+          - name
+          - description
     SkillGroup:
       description: |
         Details describing a skill group.
@@ -1048,11 +1048,11 @@ components:
           description: |
             List of skills under this skill group.
       required:
-      - "id"
-      - "name"
-      - "description"
-      - "skillCategoryId"
-      - "skills"
+        - "id"
+        - "name"
+        - "description"
+        - "skillCategoryId"
+        - "skills"
     SkillGroupList:
       type: "array"
       items:
@@ -1072,9 +1072,9 @@ components:
             description: |
               The localized description of the skill group.
         required:
-        - id
-        - name
-        - description
+          - id
+          - name
+          - description
     SkillCategory:
       description: |
         Details describing a skill category.
@@ -1099,10 +1099,10 @@ components:
           description: |
             List of skill groups under this skill category.
       required:
-      - "id"
-      - "name"
-      - "description"
-      - "skillGroups"
+        - "id"
+        - "name"
+        - "description"
+        - "skillGroups"
     SkillCategoryList:
       type: "array"
       items:
@@ -1122,9 +1122,9 @@ components:
             description: |
               The localized description of the skill category.
         required:
-        - id
-        - name
-        - description
+          - id
+          - name
+          - description
     SkillExtractionInput:
       description: |
         The text to extract skills from, such as a job description or course outline.
@@ -1142,7 +1142,7 @@ components:
           type: string
           description: |
             Identifies the language of the input text.
-          
+            
             Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
             
             If no value is specified, the response language is used.
@@ -1155,7 +1155,7 @@ components:
 
             If no value is specified, the default limit of 10 skills is used.
       required:
-      - content
+        - content
     SkillExtractionOutput:
       type: "array"
       items:
@@ -1179,10 +1179,10 @@ components:
             description: |
               The score representing the confidence level of the match between the extracted skill and the standardized skill in Visier’s Skills Library. The score ranges from 0 to 100.
         required:
-        - id
-        - name
-        - description
-        - score
+          - id
+          - name
+          - description
+          - score
     SkillMatchInput:
       description: |
         The skill set and the group of skill sets (targets) to be matched.
@@ -1244,7 +1244,7 @@ components:
               -
                 - "21577"
                 - 40
-            - 
+            -
               -
                 - "15812"
                 - 90
@@ -1265,7 +1265,7 @@ components:
                 - "19237"
                 - 66
       required:
-      - content
+        - content
     SkillMatchOutput:
       type: array
       minItems: 1
@@ -1298,15 +1298,15 @@ components:
           description: |
             A root cause identifier that allows Visier to determine the source of the problem.
       required:
-      - errorCode
-      - message
-      - rci
+        - errorCode
+        - message
+        - rci
 
 x-amazon-apigateway-gateway-responses:
   # We don't have auth between Alpine front door and this API GW,
   # so, missing auth token means we are simply requesting for a resource that does not exist.
   MISSING_AUTHENTICATION_TOKEN:
-    statusCode: 404 
+    statusCode: 404
     responseParameters: {}
     responseTemplates:
       application/json: "{\"errorCode\":\"USER_INPUT_ERROR\",\"message\":\"Resource not found\",\"rci\":\"RCI9000001\"}"
@@ -1318,7 +1318,7 @@ x-amazon-apigateway-gateway-responses:
     responseTemplates:
       application/json: "{\"errorCode\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Internal server error\",\"rci\":\"RCI9000002\"}"
   DEFAULT_5XX:
-    statusCode: 500 
+    statusCode: 500
     responseParameters: {}
     responseTemplates:
       application/json: "{\"errorCode\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Internal server error\",\"rci\":\"RCI9000003\"}"

--- a/res/skills-intelligence-engine.yaml
+++ b/res/skills-intelligence-engine.yaml
@@ -9,12 +9,12 @@ info:
   version: "1.0.0"
 
 tags:
-  - name: Jobs Library
-    description: |
-      Access over 3,300 standard jobs and get complete details in 27 languages, such as alternative titles, descriptions, and skills.
-  - name: Skills Library
-    description: |
-      Access over 14,000 skills and get complete skill details in 27 languages, such as alternative titles, descriptions, and hierarchies.
+- name: Jobs Library
+  description: |
+    Access over 3,300 standard jobs and get complete details in 27 languages, such as alternative titles, descriptions, and skills.
+- name: Skills Library
+  description: |
+    Access over 14,000 skills and get complete skill details in 27 languages, such as alternative titles, descriptions, and hierarchies.
 
 paths:
   /v1/jobs/{id}:
@@ -25,23 +25,23 @@ paths:
       description: |
         If you know the ID of a job, use this endpoint to retrieve information such as display name, description, Automation Index, Remote Work Index, alternative names, and skills.
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-          description: |
-            The ID of the job to retrieve details for.
-        - name: "Accept-Language"
-          in: "header"
-          schema:
-            type: "string"
-          description: |
-            Allows you to specify if you want the output to be in one of the accepted languages.
-            
-            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-            
-            If no value is specified, the response language is English.
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+        description: |
+          The ID of the job to retrieve details for.
+      - name: "Accept-Language"
+        in: "header"
+        schema:
+          type: "string"
+        description: |
+          Allows you to specify if you want the output to be in one of the accepted languages.
+
+          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+
+          If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -77,7 +77,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-get-job-arn}"
       security:
-        - api_key: []
+      - api_key: []
   /v1/jobs:
     get:
       summary: Retrieve a list of jobs
@@ -86,16 +86,16 @@ paths:
       description: |
         Use this endpoint to retrieve all the jobs in Visier's Jobs Library.
       parameters:
-        - name: "Accept-Language"
-          in: "header"
-          schema:
-            type: "string"
-          description: |
-            Allows you to specify if you want the output to be in one of the accepted languages.
-            
-            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-            
-            If no value is specified, the response language is English.
+      - name: "Accept-Language"
+        in: "header"
+        schema:
+          type: "string"
+        description: |
+          Allows you to specify if you want the output to be in one of the accepted languages.
+
+          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+
+          If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -131,7 +131,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-list-jobs-arn}"
       security:
-        - api_key: []
+      - api_key: []
   /v1/jobs/search:
     get:
       summary: Search jobs
@@ -140,23 +140,23 @@ paths:
       description: |
         Retrieve a list of jobs that match a specified search term.
       parameters:
-        - name: "term"
-          in: "query"
-          required: true
-          schema:
-            type: "string"
-          description: |
-            The term to search for. The search term must be URL encoded and the minimum length is 3 characters.
-        - name: "Accept-Language"
-          in: "header"
-          schema:
-            type: "string"
-          description: |
-            Allows you to specify if you want the output to be in one of the accepted languages.
-            
-            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-            
-            If no value is specified, the response language is English.
+      - name: "term"
+        in: "query"
+        required: true
+        schema:
+          type: "string"
+        description: |
+          The term to search for. The search term must be URL encoded and the minimum length is 3 characters.
+      - name: "Accept-Language"
+        in: "header"
+        schema:
+          type: "string"
+        description: |
+          Allows you to specify if you want the output to be in one of the accepted languages.
+
+          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+
+          If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -192,7 +192,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-search-job-arn}"
       security:
-        - api_key: []
+      - api_key: []
   /v1/jobs/standardize:
     post:
       summary: Standardize custom job titles
@@ -245,7 +245,7 @@ paths:
         uri: "${lambda-standardize-job-arn}"
         type: "aws_proxy"
       security:
-        - api_key: []
+      - api_key: []
   /v1/skills/{id}:
     get:
       summary: Get skill details by ID
@@ -254,23 +254,23 @@ paths:
       description: |
         If you know the ID of a skill, use this endpoint to retrieve information such as display name, description, Automation Index, Remote Work Index, and alternative names.
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-          description: |
-            The ID of the skill to retrieve details for.
-        - name: "Accept-Language"
-          in: "header"
-          schema:
-            type: "string"
-          description: |
-            Allows you to specify if you want the output to be in one of the accepted languages.
-            
-            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-            
-            If no value is specified, the response language is English.
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+        description: |
+          The ID of the skill to retrieve details for.
+      - name: "Accept-Language"
+        in: "header"
+        schema:
+          type: "string"
+        description: |
+          Allows you to specify if you want the output to be in one of the accepted languages.
+
+          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+
+          If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -306,7 +306,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-get-skill-arn}"
       security:
-        - api_key: []
+      - api_key: []
   /v1/skills:
     get:
       summary: Retrieve a list of skills
@@ -315,28 +315,28 @@ paths:
       description: |
         Use this endpoint to retrieve all skills in Visier's Skills Library.
       parameters:
-        - name: "skillGroupId"
-          in: "query"
-          schema:
-            type: "string"
-          description: |
-            Filter only skills that belong to a certain skill group.
-        - name: "skillCategoryId"
-          in: "query"
-          schema:
-            type: "string"
-          description: |
-            Filter only skills that belong to a certain skill category.
-        - name: "Accept-Language"
-          in: "header"
-          schema:
-            type: "string"
-          description: |
-            Allows you to specify if you want the output to be in one of the accepted languages.
-            
-            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-            
-            If no value is specified, the response language is English.
+      - name: "skillGroupId"
+        in: "query"
+        schema:
+          type: "string"
+        description: |
+          Filter only skills that belong to a certain skill group.
+      - name: "skillCategoryId"
+        in: "query"
+        schema:
+          type: "string"
+        description: |
+          Filter only skills that belong to a certain skill category.
+      - name: "Accept-Language"
+        in: "header"
+        schema:
+          type: "string"
+        description: |
+          Allows you to specify if you want the output to be in one of the accepted languages.
+
+          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+
+          If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -372,7 +372,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-list-skills-arn}"
       security:
-        - api_key: []
+      - api_key: []
   /v1/skills/search:
     get:
       summary: Search skills
@@ -381,23 +381,23 @@ paths:
       description: |
         Retrieve a list of skills that match a specified search term.
       parameters:
-        - name: "term"
-          in: "query"
-          required: true
-          schema:
-            type: "string"
-          description: |
-            The term to search for. The search term must be URL encoded and the minimum length is 3 characters.
-        - name: "Accept-Language"
-          in: "header"
-          schema:
-            type: "string"
-          description: |
-            Allows you to specify if you want the output to be in one of the accepted languages.
-            
-            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-            
-            If no value is specified, the response language is English.
+      - name: "term"
+        in: "query"
+        required: true
+        schema:
+          type: "string"
+        description: |
+          The term to search for. The search term must be URL encoded and the minimum length is 3 characters.
+      - name: "Accept-Language"
+        in: "header"
+        schema:
+          type: "string"
+        description: |
+          Allows you to specify if you want the output to be in one of the accepted languages.
+
+          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+
+          If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -433,7 +433,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-search-skill-arn}"
       security:
-        - api_key: []
+      - api_key: []
   /v1/skills/extract:
     post:
       summary: Extract skills from text
@@ -442,16 +442,16 @@ paths:
       description: |
         Extract the relevant skills from text such as job descriptions and course outlines.
       parameters:
-        - name: "Accept-Language"
-          in: "header"
-          schema:
-            type: "string"
-          description: |
-            Allows you to specify if you want the output to be in one of the accepted languages.
-            
-            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-            
-            If no value is specified, the response language is English.
+      - name: "Accept-Language"
+        in: "header"
+        schema:
+          type: "string"
+        description: |
+          Allows you to specify if you want the output to be in one of the accepted languages.
+          
+          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+          
+          If no value is specified, the response language is English.
       requestBody:
         description: |
           The text to extract skills from.
@@ -496,7 +496,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-extract-skills-arn}"
       security:
-        - api_key: []
+      - api_key: []
   /v1/skills/match:
     post:
       summary: Match a skill set to a group of skill sets (targets)
@@ -546,7 +546,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-match-skills-arn}"
       security:
-        - api_key: []
+      - api_key: []
   /v1/skill-groups/{id}:
     get:
       summary: Get skill group details by ID
@@ -555,23 +555,23 @@ paths:
       description: |
         If you know the ID of a skill group, use this endpoint to retrieve information such as display name, description, Automation Index, Remote Work Index, and alternative names.
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-          description: |
-            The ID of the skill group to retrieve details for.
-        - name: "Accept-Language"
-          in: "header"
-          schema:
-            type: "string"
-          description: |
-            Allows you to specify if you want the output to be in one of the accepted languages.
-            
-            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-            
-            If no value is specified, the response language is English.
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+        description: |
+          The ID of the skill group to retrieve details for.
+      - name: "Accept-Language"
+        in: "header"
+        schema:
+          type: "string"
+        description: |
+          Allows you to specify if you want the output to be in one of the accepted languages.
+
+          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+
+          If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -607,7 +607,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-get-meta-skill-arn}"
       security:
-        - api_key: []
+      - api_key: []
   /v1/skill-groups:
     get:
       summary: Retrieve a list of skill groups
@@ -616,22 +616,22 @@ paths:
       description: |
         Use this endpoint to retrieve all skill groups in Visier's Skills Library.
       parameters:
-        - name: "skillCategoryId"
-          in: "query"
-          schema:
-            type: "string"
-          description: |
-            Filter only skills that belong to a certain skill category.
-        - name: "Accept-Language"
-          in: "header"
-          schema:
-            type: "string"
-          description: |
-            Allows you to specify if you want the output to be in one of the accepted languages.
-            
-            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-            
-            If no value is specified, the response language is English.
+      - name: "skillCategoryId"
+        in: "query"
+        schema:
+          type: "string"
+        description: |
+          Filter only skills that belong to a certain skill category.
+      - name: "Accept-Language"
+        in: "header"
+        schema:
+          type: "string"
+        description: |
+          Allows you to specify if you want the output to be in one of the accepted languages.
+
+          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+
+          If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -667,7 +667,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-list-meta-skills-arn}"
       security:
-        - api_key: []
+      - api_key: []
   /v1/skill-categories/{id}:
     get:
       summary: Get skill category details by ID
@@ -676,23 +676,23 @@ paths:
       description: |
         If you know the ID of a skill category, use this endpoint to retrieve information such as display name, description, Automation Index, Remote Work Index, and alternative names.
       parameters:
-        - name: "id"
-          in: "path"
-          required: true
-          schema:
-            type: "string"
-          description: |
-            The ID of the skill category to retrieve details for.
-        - name: "Accept-Language"
-          in: "header"
-          schema:
-            type: "string"
-          description: |
-            Allows you to specify if you want the output to be in one of the accepted languages.
-            
-            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-            
-            If no value is specified, the response language is English.
+      - name: "id"
+        in: "path"
+        required: true
+        schema:
+          type: "string"
+        description: |
+          The ID of the skill category to retrieve details for.
+      - name: "Accept-Language"
+        in: "header"
+        schema:
+          type: "string"
+        description: |
+          Allows you to specify if you want the output to be in one of the accepted languages.
+
+          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+
+          If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -728,7 +728,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-get-super-skill-arn}"
       security:
-        - api_key: []
+      - api_key: []
   /v1/skill-categories:
     get:
       summary: Retrieve a list of skill categories
@@ -737,16 +737,16 @@ paths:
       description: |
         Use this endpoint to retrieve all skill categories in Visier's Skills Library.
       parameters:
-        - name: "Accept-Language"
-          in: "header"
-          schema:
-            type: "string"
-          description: |
-            Allows you to specify if you want the output to be in one of the accepted languages.
-            
-            Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
-            
-            If no value is specified, the response language is English.
+      - name: "Accept-Language"
+        in: "header"
+        schema:
+          type: "string"
+        description: |
+          Allows you to specify if you want the output to be in one of the accepted languages.
+
+          Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
+
+          If no value is specified, the response language is English.
       responses:
         "200":
           description: |
@@ -782,7 +782,7 @@ paths:
         httpMethod: "POST"
         uri: "${lambda-list-super-skills-arn}"
       security:
-        - api_key: []
+      - api_key: []
 
 components:
   securitySchemes:
@@ -818,9 +818,9 @@ components:
         socCode:
           type: "string"
           description: |
-            The Standard Occupational Classification (SOC) code of the job.
-            
-            This field will be omitted if the job is not associated with a SOC code.
+           The Standard Occupational Classification (SOC) code of the job.
+
+           This field will be omitted if the job is not associated with a SOC code.
         alternativeTitles:
           type: "array"
           items:
@@ -852,12 +852,12 @@ components:
 
             This field will be omitted if automation is not applicable to the job.
       required:
-        - "id"
-        - "name"
-        - "description"
-        - "alternativeTitles"
-        - "essentialSkills"
-        - "optionalSkills"
+      - "id"
+      - "name"
+      - "description"
+      - "alternativeTitles"
+      - "essentialSkills"
+      - "optionalSkills"
     JobList:
       type: "array"
       items:
@@ -877,9 +877,9 @@ components:
             description: |
               The localized description of the job.
         required:
-          - id
-          - name
-          - description
+        - id
+        - name
+        - description
     JobStandardizationInput:
       description: |
         The custom job titles to standardize.
@@ -896,7 +896,7 @@ components:
             
             If `naicsCode` is provided, the most relevant job titles associated with the naicsCode are returned first.
       required:
-        - "jobs"
+      - "jobs"
     JobStandardizationOutput:
       type: "array"
       items:
@@ -931,13 +931,13 @@ components:
                   description: |
                     The score representing the confidence level of the match between the standardized job and the custom job title input. The score ranges from 0 to 100.
               required:
-                - id
-                - name
-                - description
-                - score
+              - id
+              - name
+              - description
+              - score
         required:
-          - job
-          - matches
+        - job
+        - matches
     Skill:
       description: |
         The details describing a skill.
@@ -962,7 +962,7 @@ components:
         skillCategoryId:
           type: "string"
           description: |
-            ID of the skill category that this skill belongs to.
+            ID of the skill category that this skill belongs to. 
         isKnowledge:
           type: "boolean"
           description: |
@@ -990,14 +990,14 @@ components:
 
             This field will be omitted if automation is not applicable to the skill.
       required:
-        - "id"
-        - "name"
-        - "description"
-        - "skillGroupId"
-        - "skillCategoryId"
-        - "isKnowledge"
-        - "skillType"
-        - "alternativeTitles"
+      - "id"
+      - "name"
+      - "description"
+      - "skillGroupId"
+      - "skillCategoryId"
+      - "isKnowledge"
+      - "skillType"
+      - "alternativeTitles"
     SkillList:
       type: "array"
       items:
@@ -1017,9 +1017,9 @@ components:
             description: |
               The localized description of the skill.
         required:
-          - id
-          - name
-          - description
+        - id
+        - name
+        - description
     SkillGroup:
       description: |
         Details describing a skill group.
@@ -1048,11 +1048,11 @@ components:
           description: |
             List of skills under this skill group.
       required:
-        - "id"
-        - "name"
-        - "description"
-        - "skillCategoryId"
-        - "skills"
+      - "id"
+      - "name"
+      - "description"
+      - "skillCategoryId"
+      - "skills"
     SkillGroupList:
       type: "array"
       items:
@@ -1072,9 +1072,9 @@ components:
             description: |
               The localized description of the skill group.
         required:
-          - id
-          - name
-          - description
+        - id
+        - name
+        - description
     SkillCategory:
       description: |
         Details describing a skill category.
@@ -1099,10 +1099,10 @@ components:
           description: |
             List of skill groups under this skill category.
       required:
-        - "id"
-        - "name"
-        - "description"
-        - "skillGroups"
+      - "id"
+      - "name"
+      - "description"
+      - "skillGroups"
     SkillCategoryList:
       type: "array"
       items:
@@ -1122,9 +1122,9 @@ components:
             description: |
               The localized description of the skill category.
         required:
-          - id
-          - name
-          - description
+        - id
+        - name
+        - description
     SkillExtractionInput:
       description: |
         The text to extract skills from, such as a job description or course outline.
@@ -1142,7 +1142,7 @@ components:
           type: string
           description: |
             Identifies the language of the input text.
-            
+          
             Format: **ISO 639-1** language code. For a list of supported languages, see "Supported Languages" in the Skills Intelligence Engine API documentation.
             
             If no value is specified, the response language is used.
@@ -1155,7 +1155,7 @@ components:
 
             If no value is specified, the default limit of 10 skills is used.
       required:
-        - content
+      - content
     SkillExtractionOutput:
       type: "array"
       items:
@@ -1179,10 +1179,10 @@ components:
             description: |
               The score representing the confidence level of the match between the extracted skill and the standardized skill in Visier’s Skills Library. The score ranges from 0 to 100.
         required:
-          - id
-          - name
-          - description
-          - score
+        - id
+        - name
+        - description
+        - score
     SkillMatchInput:
       description: |
         The skill set and the group of skill sets (targets) to be matched.
@@ -1244,7 +1244,7 @@ components:
               -
                 - "21577"
                 - 40
-            -
+            - 
               -
                 - "15812"
                 - 90
@@ -1265,7 +1265,7 @@ components:
                 - "19237"
                 - 66
       required:
-        - content
+      - content
     SkillMatchOutput:
       type: array
       minItems: 1
@@ -1298,15 +1298,15 @@ components:
           description: |
             A root cause identifier that allows Visier to determine the source of the problem.
       required:
-        - errorCode
-        - message
-        - rci
+      - errorCode
+      - message
+      - rci
 
 x-amazon-apigateway-gateway-responses:
   # We don't have auth between Alpine front door and this API GW,
   # so, missing auth token means we are simply requesting for a resource that does not exist.
   MISSING_AUTHENTICATION_TOKEN:
-    statusCode: 404
+    statusCode: 404 
     responseParameters: {}
     responseTemplates:
       application/json: "{\"errorCode\":\"USER_INPUT_ERROR\",\"message\":\"Resource not found\",\"rci\":\"RCI9000001\"}"
@@ -1318,7 +1318,7 @@ x-amazon-apigateway-gateway-responses:
     responseTemplates:
       application/json: "{\"errorCode\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Internal server error\",\"rci\":\"RCI9000002\"}"
   DEFAULT_5XX:
-    statusCode: 500
+    statusCode: 500 
     responseParameters: {}
     responseTemplates:
       application/json: "{\"errorCode\":\"INTERNAL_SERVER_ERROR\",\"message\":\"Internal server error\",\"rci\":\"RCI9000003\"}"

--- a/res/skills-intelligence-engine.yaml
+++ b/res/skills-intelligence-engine.yaml
@@ -208,7 +208,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JobStandardizationInput"
+              $ref: "#/components/schemas/JobStandardizationInputSkills"
         required: true
       responses:
         "200":
@@ -217,7 +217,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobStandardizationOutput"
+                $ref: "#/components/schemas/JobStandardizationOutputSkills"
         "400":
           description: |
             The API request failed given the parameters provided, such as missing or invalid parameters.
@@ -880,7 +880,7 @@ components:
         - id
         - name
         - description
-    JobStandardizationInput:
+    JobStandardizationInputSkills:
       description: |
         The custom job titles to standardize.
       type: "object"
@@ -897,7 +897,7 @@ components:
             If `naicsCode` is provided, the most relevant job titles associated with the naicsCode are returned first.
       required:
       - "jobs"
-    JobStandardizationOutput:
+    JobStandardizationOutputSkills:
       type: "array"
       items:
         title: OutputEntry


### PR DESCRIPTION
`JobStandardizationInput` and `JobStandardizationOutput` exist in both Compensation Benchmarks and Skills Intelligence Engine. We have added `Skills` to the back of the schemas on the Skills Intelligence Engine side.