### PR TITLE
Fix schema name conflicts between Skills Intelligence Engine and Compensation Benchmark APIs

### DIFF
--- a/res/skills-intelligence-engine.yaml
+++ b/res/skills-intelligence-engine.yaml
@@ -208,7 +208,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/JobStandardizationInput"
+              $ref: "#/components/schemas/JobStandardizationInputSkills"
         required: true
       responses:
         "200":
@@ -217,7 +217,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/JobStandardizationOutput"
+                $ref: "#/components/schemas/JobStandardizationOutputSkills"
         "400":
           description: |
             The API request failed given the parameters provided, such as missing or invalid parameters.
@@ -880,7 +880,7 @@ components:
         - id
         - name
         - description
-    JobStandardizationInput:
+    JobStandardizationInputSkills:
       description: |
         The custom job titles to standardize.
       type: "object"
@@ -897,7 +897,7 @@ components:
             If `naicsCode` is provided, the most relevant job titles associated with the naicsCode are returned first.
       required:
       - "jobs"
-    JobStandardizationOutput:
+    JobStandardizationOutputSkills:
       type: "array"
       items:
         title: OutputEntry


### PR DESCRIPTION
`JobStandardizationInput` and `JobStandardizationOutput` exists in both Skills Intelligence Engine and Compensation Benchmark APIs; to address the naming conflict we discovered, `Skills` has been added tot he end of the name in Skills Intelligence Engine.