### PR TITLE
[VAN-137234] Fixed version extraction for generated sdk.

### DIFF
--- a/sdk-blueprints/preprocessing/preprocessing.py
+++ b/sdk-blueprints/preprocessing/preprocessing.py
@@ -26,7 +26,7 @@ def load_yaml(file_path):
 
 def save_yaml(data, file_path):
     with open(file_path, 'w') as file:
-        yaml.safe_dump(data, file)
+        yaml.safe_dump(data, file, sort_keys=False)
 
 
 def find_null_schemas(spec):

--- a/sdk-blueprints/python/generate-package.sh
+++ b/sdk-blueprints/python/generate-package.sh
@@ -21,11 +21,10 @@ output_api_dir="$4/$package_name"
 templates_dir="$blueprints_dir/templates"
 
 # Extract the specification version
-spec_version=$(awk '/version:/ {
-    gsub(/"| /, "", $2);
-    sub(/[0-9]+\./, "0.", $2);
-    print $2
-}' "$spec_file")
+spec_version=$(grep -A10 "^info:" "$spec_file" | \
+               grep "version:" | \
+               head -1 | \
+               awk '{gsub(/"| /, "", $2); print $2}')
 
 if [ -n "$version_postfix" ]; then
     spec_version="${spec_version}.${version_postfix}"

--- a/sdk-blueprints/python/generate-package.sh
+++ b/sdk-blueprints/python/generate-package.sh
@@ -21,10 +21,7 @@ output_api_dir="$4/$package_name"
 templates_dir="$blueprints_dir/templates"
 
 # Extract the specification version
-spec_version=$(grep -A10 "^info:" "$spec_file" | \
-               grep "version:" | \
-               head -1 | \
-               awk '{gsub(/"| /, "", $2); print $2}')
+spec_version=$(grep -E "version: [0-9\.]+" "$spec_file" | grep -oE "[0-9\.]+")
 
 if [ -n "$version_postfix" ]; then
     spec_version="${spec_version}.${version_postfix}"


### PR DESCRIPTION
A bug occurred in the version extraction process in generating script. 

This issue stemmed from an incorrect sequencing when saving preprocessing YAML files. 
While this wasn’t the root cause of the problem, it triggered the error condition.